### PR TITLE
Bump to 0.90.1

### DIFF
--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -21,7 +21,7 @@ jobs:
       shell: bash -l {0}
       run: ./package.sh
       env:
-        POPPLER_VERSION: "0.90.0"
+        POPPLER_VERSION: "0.90.1"
         PKGS_PATH_DIR: /c/Users/runneradmin/conda_pkgs_dir
     - name: Zip Release
       run: Compress-Archive D:\a\poppler-windows\poppler-windows\poppler* release.zip


### PR DESCRIPTION
Package for poppler v0.90.1

# Checklist:

- [x] I have confirmed that [poppler-feedstock](https://github.com/conda-forge/poppler-feedstock) has been updated.
- [x] I have bumped `.github/workflows/package.yaml's POPPLER_VERSION` to the current build.