### PR TITLE
Update package.sh for Poppler version 21.01.0

### DIFF
--- a/package.sh
+++ b/package.sh
@@ -1,4 +1,4 @@
-POPPLER_VERSION=20.12.1
+POPPLER_VERSION=21.01.0
 POPPLER_DATA_URL="https://poppler.freedesktop.org/poppler-data-0.4.10.tar.gz"
 
 mkdir "poppler-$POPPLER_VERSION"


### PR DESCRIPTION
Package for poppler v20.01.0

# Checklist:

- [x] I have confirmed that [poppler-feedstock](https://github.com/conda-forge/poppler-feedstock) has been updated.
- [X] I have bumped `package.sh` `POPPLER_VERSION` to the current build.
