### PR TITLE
build: add dependabot config to keep actions up to date

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+    - package-ecosystem: github-actions
+      directory: /
+      schedule:
+          interval: monthly
+      open-pull-requests-limit: 10


### PR DESCRIPTION
Dependabot can be used to keep GitHub Actions used in `.github/workflows` up to date.

See https://docs.github.com/en/github/administering-a-repository/keeping-your-actions-up-to-date-with-dependabot#example-dependabotyml-file-for-github-actions