### PR TITLE
Update poppler package to 21.08.0

### DIFF
--- a/package.sh
+++ b/package.sh
@@ -1,5 +1,5 @@
-POPPLER_VERSION=21.03.0
-POPPLER_DATA_URL="https://poppler.freedesktop.org/poppler-data-0.4.10.tar.gz"
+POPPLER_VERSION=21.08.0
+POPPLER_DATA_URL="https://poppler.freedesktop.org/poppler-21.08.0.tar.xz"
 
 mkdir "poppler-$POPPLER_VERSION"
 cd "poppler-$POPPLER_VERSION" || exit

--- a/package.sh
+++ b/package.sh
@@ -1,5 +1,5 @@
 POPPLER_VERSION=21.08.0
-POPPLER_DATA_URL="https://poppler.freedesktop.org/poppler-21.08.0.tar.xz"
+POPPLER_DATA_URL="https://poppler.freedesktop.org/poppler-data-0.4.10.tar.gz"
 
 mkdir "poppler-$POPPLER_VERSION"
 cd "poppler-$POPPLER_VERSION" || exit


### PR DESCRIPTION
Package for poppler v21.08.0

# Checklist:

- [x] I have confirmed that [poppler-feedstock](https://github.com/conda-forge/poppler-feedstock) has been updated.
- [x] I have bumped `package.sh` `POPPLER_VERSION` to the current build.
