### PR TITLE
Add new dlls for 21.08.0

### DIFF
--- a/package.sh
+++ b/package.sh
@@ -17,6 +17,9 @@ cp "$PKGS_PATH_DIR"/openssl*/Library/bin/libcrypto-1_1-x64.dll ./Library/bin/
 cp "$PKGS_PATH_DIR"/openjpeg*/Library/bin/openjp2.dll ./Library/bin/
 cp "$PKGS_PATH_DIR"/xz*/Library/bin/liblzma.dll ./Library/bin/
 cp "$PKGS_PATH_DIR"/cairo*/Library/bin/cairo.dll ./Library/bin/
+cp "$PKGS_PATH_DIR"/libdeflate*/Library/bin/libdeflate.dll ./Library/bin/
+cp "$PKGS_PATH_DIR"/lerc*/Library/bin/Lerc.dll ./Library/bin/
+cp "$PKGS_PATH_DIR"/jbig*/Library/bin/jbig.dll ./Library/bin/
 
 mkdir -p share/poppler
 cd share || exit


### PR DESCRIPTION
Still looking for `lcms2.dll`