### PR TITLE
Poppler 21.09.0

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,7 +2,7 @@ name: Package Test
 
 on:
   pull_request:
-    types: [ synchronize ]
+    types: [ synchronize, opened ]
       
 jobs:
   package:

--- a/package.sh
+++ b/package.sh
@@ -1,5 +1,5 @@
-POPPLER_VERSION=21.08.0
-POPPLER_DATA_URL="https://poppler.freedesktop.org/poppler-data-0.4.10.tar.gz"
+POPPLER_VERSION=21.09.0
+POPPLER_DATA_URL="https://poppler.freedesktop.org/poppler-data-0.4.11.tar.gz"
 
 set -e 
 set -o pipefail


### PR DESCRIPTION
Package 21.09.0
Update poppler-data to 0.4.11

# Checklist:

- [x] I have confirmed that [poppler-feedstock](https://github.com/conda-forge/poppler-feedstock) has been updated.
- [x] I have bumped `package.sh` `POPPLER_VERSION` to the current build.
