### PR TITLE
Add build number to track feedstock changes

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,14 +23,14 @@ jobs:
       env:
         PKGS_PATH_DIR: /c/Users/runneradmin/conda_pkgs_dir
     - name: Zip Release
-      run: Compress-Archive D:\a\poppler-windows\poppler-windows\poppler-${{ env.POPPLER_VERSION }} Release-${{ env.POPPLER_VERSION }}.zip
+      run: Compress-Archive D:\a\poppler-windows\poppler-windows\poppler-${{ env.POPPLER_VERSION }} Release-${{ env.POPPLER_VERSION }}-${{ env.BUILD }}.zip
       shell: pwsh
     - name: Create tag
       id: tag_version
       uses: mathieudutour/github-tag-action@v5.6
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        custom_tag: ${{ env.POPPLER_VERSION }}
+        custom_tag: ${{ env.POPPLER_VERSION }}-${{ env.BUILD }}
     - name: Create Release
       id: create_release
       uses: actions/create-release@v1
@@ -38,7 +38,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         tag_name: ${{ steps.tag_version.outputs.new_tag }}
-        release_name: Release ${{ env.POPPLER_VERSION }}
+        release_name: Release ${{ env.POPPLER_VERSION }}-${{ env.BUILD }}
         draft: false
         prerelease: false
     - name: Upload Release Asset
@@ -48,6 +48,6 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: D:\a\poppler-windows\poppler-windows\Release-${{ env.POPPLER_VERSION }}.zip
-        asset_name: Release-${{ env.POPPLER_VERSION }}.zip
+        asset_path: D:\a\poppler-windows\poppler-windows\Release-${{ env.POPPLER_VERSION }}-${{ env.BUILD }}.zip
+        asset_name: Release-${{ env.POPPLER_VERSION }}-${{ env.BUILD }}.zip
         asset_content_type: application/zip

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -46,10 +46,10 @@ jobs:
       run: D:\a\poppler-windows\poppler-windows\poppler-${{ env.POPPLER_VERSION }}\Library\bin\pdfunite.exe -v
 
     - name: Zip Release
-      run: Compress-Archive D:\a\poppler-windows\poppler-windows\poppler-${{ env.POPPLER_VERSION }} Release-${{ env.POPPLER_VERSION }}.zip
+      run: Compress-Archive D:\a\poppler-windows\poppler-windows\poppler-${{ env.POPPLER_VERSION }} Release-${{ env.POPPLER_VERSION }}-${{ env.BUILD }}.zip
       shell: pwsh
     - name: Upload Artifact
       uses: actions/upload-artifact@v2
       with:
-        name: Poppler-${{ env.POPPLER_VERSION }}
-        path: D:\a\poppler-windows\poppler-windows\Release-${{ env.POPPLER_VERSION }}.zip
+        name: Poppler-${{ env.POPPLER_VERSION }}-${{ env.BUILD }}
+        path: D:\a\poppler-windows\poppler-windows\Release-${{ env.POPPLER_VERSION }}-${{ env.BUILD }}.zip

--- a/README.md
+++ b/README.md
@@ -13,12 +13,16 @@ You can download the latest build from [releases](https://github.com/oschwartz10
 
 - Create a new pull request and bump `POPPLER_VERSION` in `package.sh` to the latest.  
 
+- Sometimes the feedstock does an update on the same version in order to apply a fix and we need to do a repackage here. If the version has been packaged already, increase the build number by 1 in `package.sh`. If it has not been packaged yet, reset the build number to 0.
+
 - After merged the tag will be matched and the workflow will trigger a new release.
 
 ### Poppler-data out of date?
 
 - Copy the latest download link for poppler-data from the [offical poppler site](https://poppler.freedesktop.org/).
 
-- Create a new pull request and update the `POPPLER_DATA_URL` under in `package.sh`.  
+- Create a new pull request and update the `POPPLER_DATA_URL` under in `package.sh`. 
+
+- Sometimes the feedstock does an update on the same version in order to apply a fix and we need to do a repackage here. If the version has been packaged already, increase the build number by 1 in `package.sh`. If it has not been packaged yet, reset the build number to 0.
 
 - After merged the tag will be matched and the workflow will trigger a new release.

--- a/package.sh
+++ b/package.sh
@@ -1,7 +1,8 @@
 POPPLER_VERSION=21.09.0
 POPPLER_DATA_URL="https://poppler.freedesktop.org/poppler-data-0.4.11.tar.gz"
+BUILD="1"
 
-set -e 
+set -e
 set -o pipefail
 
 mkdir "poppler-$POPPLER_VERSION"
@@ -36,3 +37,4 @@ tar xvzf poppler-data.tar.gz -C poppler --strip-components 1
 rm poppler-data.tar.gz
 
 echo "POPPLER_VERSION=$POPPLER_VERSION" >> "$GITHUB_ENV"
+echo "BUILD=$BUILD" >> "$GITHUB_ENV"


### PR DESCRIPTION
Sometimes the feedstock will rebuild the package with a fix as is the case with 21.09.0. The idea here is to increase the build number of the same version to create a new release with an update, but to keep the old version.

See new README.