### PR TITLE
Poppler 22.01.0

### DIFF
--- a/package.sh
+++ b/package.sh
@@ -1,4 +1,4 @@
-POPPLER_VERSION=21.11.0
+POPPLER_VERSION=21.12.0
 POPPLER_DATA_URL="https://poppler.freedesktop.org/poppler-data-0.4.11.tar.gz"
 BUILD="0"
 

--- a/package.sh
+++ b/package.sh
@@ -1,4 +1,4 @@
-POPPLER_VERSION=21.12.0
+POPPLER_VERSION=22.01.0
 POPPLER_DATA_URL="https://poppler.freedesktop.org/poppler-data-0.4.11.tar.gz"
 BUILD="0"
 


### PR DESCRIPTION
Package for poppler v22.01.0

Edit: typo

Edit2: v21.12.0 -> 22.01.0

# Checklist:

- [x] I have confirmed that [poppler-feedstock](https://github.com/conda-forge/poppler-feedstock) has been updated.
- [x] I have bumped `package.sh` `POPPLER_VERSION` to the current build.
