### PR TITLE
Poppler 22.04.0

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,6 +22,10 @@ jobs:
       env:
         PKGS_PATH_DIR: /c/Users/runneradmin/conda_pkgs_dir
 
+    - name: Remove Poppler
+      shell: bash -l {0}
+      run: conda remove -c conda-forge poppler -y
+
     - name: Test pdfattach
       run: D:\a\poppler-windows\poppler-windows\poppler-${{ env.POPPLER_VERSION }}\Library\bin\pdfattach.exe D:\a\poppler-windows\poppler-windows\sample.pdf D:\a\poppler-windows\poppler-windows\sample.pdf test.pdf
     - name: Test pdfdetach

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,6 +22,15 @@ jobs:
       env:
         PKGS_PATH_DIR: /c/Users/runneradmin/conda_pkgs_dir
 
+    - name: Zip Release
+      run: Compress-Archive D:\a\poppler-windows\poppler-windows\poppler-${{ env.POPPLER_VERSION }} Release-${{ env.POPPLER_VERSION }}-${{ env.BUILD }}.zip
+      shell: pwsh
+    - name: Upload Artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: Poppler-${{ env.POPPLER_VERSION }}-${{ env.BUILD }}
+        path: D:\a\poppler-windows\poppler-windows\Release-${{ env.POPPLER_VERSION }}-${{ env.BUILD }}.zip
+
     - name: Remove Poppler
       shell: bash -l {0}
       run: conda remove -c conda-forge poppler -y
@@ -48,12 +57,3 @@ jobs:
       run: D:\a\poppler-windows\poppler-windows\poppler-${{ env.POPPLER_VERSION }}\Library\bin\pdftotext.exe -v
     - name: Test pdfunite
       run: D:\a\poppler-windows\poppler-windows\poppler-${{ env.POPPLER_VERSION }}\Library\bin\pdfunite.exe -v
-
-    - name: Zip Release
-      run: Compress-Archive D:\a\poppler-windows\poppler-windows\poppler-${{ env.POPPLER_VERSION }} Release-${{ env.POPPLER_VERSION }}-${{ env.BUILD }}.zip
-      shell: pwsh
-    - name: Upload Artifact
-      uses: actions/upload-artifact@v2
-      with:
-        name: Poppler-${{ env.POPPLER_VERSION }}-${{ env.BUILD }}
-        path: D:\a\poppler-windows\poppler-windows\Release-${{ env.POPPLER_VERSION }}-${{ env.BUILD }}.zip

--- a/package.sh
+++ b/package.sh
@@ -25,7 +25,7 @@ cp "$PKGS_PATH_DIR"/libdeflate*/Library/bin/libdeflate.dll ./Library/bin/
 cp "$PKGS_PATH_DIR"/lerc*/Library/bin/Lerc.dll ./Library/bin/
 cp "$PKGS_PATH_DIR"/jbig*/Library/bin/jbig.dll ./Library/bin/
 cp "$PKGS_PATH_DIR"/lcms2*/Library/bin/lcms2.dll ./Library/bin/
-cp "$PKGS_PATH_DIR"/libxml2*/Library/bin/libxml2.dll ./Library/bin/
+# cp "$PKGS_PATH_DIR"/libxml2*/Library/bin/libxml2.dll ./Library/bin/
 cp -a "$PKGS_PATH_DIR"/libiconv*/Library/bin/. ./Library/bin/
 
 rm -rf "$PKGS_PATH_DIR"

--- a/package.sh
+++ b/package.sh
@@ -25,7 +25,7 @@ cp "$PKGS_PATH_DIR"/libdeflate*/Library/bin/libdeflate.dll ./Library/bin/
 cp "$PKGS_PATH_DIR"/lerc*/Library/bin/Lerc.dll ./Library/bin/
 cp "$PKGS_PATH_DIR"/jbig*/Library/bin/jbig.dll ./Library/bin/
 cp "$PKGS_PATH_DIR"/lcms2*/Library/bin/lcms2.dll ./Library/bin/
-# cp "$PKGS_PATH_DIR"/libxml2*/Library/bin/libxml2.dll ./Library/bin/
+cp "$PKGS_PATH_DIR"/fontconfig*/Library/bin/fontconfig-1.dll ./Library/bin/
 cp -a "$PKGS_PATH_DIR"/libiconv*/Library/bin/. ./Library/bin/
 
 rm -rf "$PKGS_PATH_DIR"

--- a/package.sh
+++ b/package.sh
@@ -1,4 +1,4 @@
-POPPLER_VERSION=22.01.0
+POPPLER_VERSION=22.04.0
 POPPLER_DATA_URL="https://poppler.freedesktop.org/poppler-data-0.4.11.tar.gz"
 BUILD="0"
 

--- a/package.sh
+++ b/package.sh
@@ -26,6 +26,7 @@ cp "$PKGS_PATH_DIR"/lerc*/Library/bin/Lerc.dll ./Library/bin/
 cp "$PKGS_PATH_DIR"/jbig*/Library/bin/jbig.dll ./Library/bin/
 cp "$PKGS_PATH_DIR"/lcms2*/Library/bin/lcms2.dll ./Library/bin/
 cp "$PKGS_PATH_DIR"/fontconfig*/Library/bin/fontconfig-1.dll ./Library/bin/
+cp "$PKGS_PATH_DIR"/expat*/Library/bin/libexpat.dll ./Library/bin/
 cp -a "$PKGS_PATH_DIR"/libiconv*/Library/bin/. ./Library/bin/
 
 rm -rf "$PKGS_PATH_DIR"


### PR DESCRIPTION
Package for poppler v22.04.0

# Checklist:

- [x] I have confirmed that [poppler-feedstock](https://github.com/conda-forge/poppler-feedstock) has been updated.
- [x] I have bumped `package.sh` `POPPLER_VERSION` to the current build.

Notes:
- Removed libxml
- New dlls for cario: fontconfig-1.dll
- Fixed tests to catch missing dlls
