### PR TITLE
Poppler 23.03.0 and data 0.4.12

### DIFF
--- a/package.sh
+++ b/package.sh
@@ -1,5 +1,5 @@
-POPPLER_VERSION=23.01.0
-POPPLER_DATA_URL="https://poppler.freedesktop.org/poppler-data-0.4.11.tar.gz"
+POPPLER_VERSION=23.03.0
+POPPLER_DATA_URL="https://poppler.freedesktop.org/poppler-data-0.4.12.tar.gz"
 BUILD="0"
 
 set -e


### PR DESCRIPTION
Package for poppler v20.**.0

# Checklist:

- [x] I have confirmed that [poppler-feedstock](https://github.com/conda-forge/poppler-feedstock) has been updated.
- [x] I have bumped `package.sh` `POPPLER_VERSION` to the current build.

Poppler data also out of date. Syncing to 0.4.12