### PR TITLE
Poppler v23.10.0

### DIFF
--- a/package.sh
+++ b/package.sh
@@ -32,6 +32,7 @@ cp "$PKGS_PATH_DIR"/fontconfig*/Library/bin/fontconfig-1.dll ./Library/bin/
 cp "$PKGS_PATH_DIR"/expat*/Library/bin/expat.dll ./Library/bin/
 cp "$PKGS_PATH_DIR"/expat*/Library/bin/expat.dll ./Library/bin/libexpat.dll
 cp -a "$PKGS_PATH_DIR"/libiconv*/Library/bin/. ./Library/bin/
+cp "$PKGS_PATH_DIR"/pixman*/Library/bin/*.dll ./Library/bin/
 
 rm -rf "$PKGS_PATH_DIR"
 

--- a/package.sh
+++ b/package.sh
@@ -1,4 +1,4 @@
-POPPLER_VERSION=23.08.0
+POPPLER_VERSION=23.10.0
 POPPLER_DATA_URL="https://poppler.freedesktop.org/poppler-data-0.4.12.tar.gz"
 BUILD="0"
 


### PR DESCRIPTION
Package for poppler v23.10.0

Supercedes #55 

# Checklist:

- [x] I have confirmed that [poppler-feedstock](https://github.com/conda-forge/poppler-feedstock) has been updated.
- [x] I have bumped `package.sh` `POPPLER_VERSION` to the current build.
