### PR TITLE
Bump to poppler 25.07.0 release July 3, 2025

### DIFF
--- a/package.sh
+++ b/package.sh
@@ -1,4 +1,4 @@
-POPPLER_VERSION=25.02.0
+POPPLER_VERSION=25.07.0
 POPPLER_DATA_URL="https://poppler.freedesktop.org/poppler-data-0.4.12.tar.gz"
 BUILD="0"
 


### PR DESCRIPTION
Package for poppler v25.07.0

# Checklist:

- [x] I have confirmed that [poppler-feedstock](https://github.com/conda-forge/poppler-feedstock) has been updated.
- [x] I have bumped `package.sh` `POPPLER_VERSION` to the current build.
