### PR TITLE
Fix missing DLLs in Poppler 26.07 package

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,9 +26,9 @@ jobs:
         PKGS_PATH_DIR: /c/Users/runneradmin/conda_pkgs_dir
     - name: Test Package
       shell: pwsh
-      run: .\test-package.ps1 -PackageRoot D:\a\poppler-windows\poppler-windows\poppler-${{ env.POPPLER_VERSION }}
+      run: .\test-package.ps1 -PackageRoot "${{ github.workspace }}\poppler-${{ env.POPPLER_VERSION }}"
     - name: Zip Release
-      run: Compress-Archive D:\a\poppler-windows\poppler-windows\poppler-${{ env.POPPLER_VERSION }} Release-${{ env.POPPLER_VERSION }}-${{ env.BUILD }}.zip
+      run: Compress-Archive "${{ github.workspace }}\poppler-${{ env.POPPLER_VERSION }}" Release-${{ env.POPPLER_VERSION }}-${{ env.BUILD }}.zip
       shell: pwsh
     - name: Create tag
       id: tag_version
@@ -53,6 +53,6 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: D:\a\poppler-windows\poppler-windows\Release-${{ env.POPPLER_VERSION }}-${{ env.BUILD }}.zip
+        asset_path: ${{ github.workspace }}\Release-${{ env.POPPLER_VERSION }}-${{ env.BUILD }}.zip
         asset_name: Release-${{ env.POPPLER_VERSION }}-${{ env.BUILD }}.zip
         asset_content_type: application/zip

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,12 +16,17 @@ jobs:
       uses: conda-incubator/setup-miniconda@v3
     - name: Install Poppler
       shell: bash -l {0}
-      run: conda install -c conda-forge liblzma expat poppler -y
+      run: |
+        POPPLER_VERSION="$(sed -n 's/^POPPLER_VERSION=//p' package.sh | tr -d '\r')"
+        conda install -c conda-forge liblzma expat "poppler=$POPPLER_VERSION" -y
     - name: Run Package Script
       shell: bash -l {0}
       run: ./package.sh
       env:
         PKGS_PATH_DIR: /c/Users/runneradmin/conda_pkgs_dir
+    - name: Test Package
+      shell: pwsh
+      run: .\test-package.ps1 -PackageRoot D:\a\poppler-windows\poppler-windows\poppler-${{ env.POPPLER_VERSION }}
     - name: Zip Release
       run: Compress-Archive D:\a\poppler-windows\poppler-windows\poppler-${{ env.POPPLER_VERSION }} Release-${{ env.POPPLER_VERSION }}-${{ env.BUILD }}.zip
       shell: pwsh

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -26,13 +26,13 @@ jobs:
 
     - name: Test Package
       shell: pwsh
-      run: .\test-package.ps1 -PackageRoot D:\a\poppler-windows\poppler-windows\poppler-${{ env.POPPLER_VERSION }}
+      run: .\test-package.ps1 -PackageRoot "${{ github.workspace }}\poppler-${{ env.POPPLER_VERSION }}"
 
     - name: Zip Release
-      run: Compress-Archive D:\a\poppler-windows\poppler-windows\poppler-${{ env.POPPLER_VERSION }} Release-${{ env.POPPLER_VERSION }}-${{ env.BUILD }}.zip
+      run: Compress-Archive "${{ github.workspace }}\poppler-${{ env.POPPLER_VERSION }}" Release-${{ env.POPPLER_VERSION }}-${{ env.BUILD }}.zip
       shell: pwsh
     - name: Upload Artifact
       uses: actions/upload-artifact@v7
       with:
         name: Poppler-${{ env.POPPLER_VERSION }}-${{ env.BUILD }}
-        path: D:\a\poppler-windows\poppler-windows\Release-${{ env.POPPLER_VERSION }}-${{ env.BUILD }}.zip
+        path: ${{ github.workspace }}\Release-${{ env.POPPLER_VERSION }}-${{ env.BUILD }}.zip

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,12 +15,18 @@ jobs:
       uses: conda-incubator/setup-miniconda@v3
     - name: Install Poppler
       shell: bash -l {0}
-      run: conda install -c conda-forge liblzma expat poppler -y
+      run: |
+        POPPLER_VERSION="$(sed -n 's/^POPPLER_VERSION=//p' package.sh | tr -d '\r')"
+        conda install -c conda-forge liblzma expat "poppler=$POPPLER_VERSION" -y
     - name: Run Package Script
       shell: bash -l {0}
       run: ./package.sh
       env:
         PKGS_PATH_DIR: /c/Users/runneradmin/conda_pkgs_dir
+
+    - name: Test Package
+      shell: pwsh
+      run: .\test-package.ps1 -PackageRoot D:\a\poppler-windows\poppler-windows\poppler-${{ env.POPPLER_VERSION }}
 
     - name: Zip Release
       run: Compress-Archive D:\a\poppler-windows\poppler-windows\poppler-${{ env.POPPLER_VERSION }} Release-${{ env.POPPLER_VERSION }}-${{ env.BUILD }}.zip
@@ -30,30 +36,3 @@ jobs:
       with:
         name: Poppler-${{ env.POPPLER_VERSION }}-${{ env.BUILD }}
         path: D:\a\poppler-windows\poppler-windows\Release-${{ env.POPPLER_VERSION }}-${{ env.BUILD }}.zip
-
-    - name: Remove Poppler
-      shell: bash -l {0}
-      run: conda remove -c conda-forge liblzma expat poppler -y
-
-    - name: Test pdfattach
-      run: D:\a\poppler-windows\poppler-windows\poppler-${{ env.POPPLER_VERSION }}\Library\bin\pdfattach.exe D:\a\poppler-windows\poppler-windows\sample.pdf D:\a\poppler-windows\poppler-windows\sample.pdf test.pdf
-    - name: Test pdfdetach
-      run: D:\a\poppler-windows\poppler-windows\poppler-${{ env.POPPLER_VERSION }}\Library\bin\pdfdetach.exe -list D:\a\poppler-windows\poppler-windows\sample.pdf
-    - name: Test pdffonts
-      run: D:\a\poppler-windows\poppler-windows\poppler-${{ env.POPPLER_VERSION }}\Library\bin\pdffonts.exe -v
-    - name: Test pdfimages
-      run: D:\a\poppler-windows\poppler-windows\poppler-${{ env.POPPLER_VERSION }}\Library\bin\pdfimages.exe -v
-    - name: Test pdfinfo
-      run: D:\a\poppler-windows\poppler-windows\poppler-${{ env.POPPLER_VERSION }}\Library\bin\pdfinfo.exe -v
-    - name: Test pdftocairo
-      run: D:\a\poppler-windows\poppler-windows\poppler-${{ env.POPPLER_VERSION }}\Library\bin\pdftocairo.exe -v
-    - name: Test pdftohtml
-      run: D:\a\poppler-windows\poppler-windows\poppler-${{ env.POPPLER_VERSION }}\Library\bin\pdftohtml.exe -v
-    - name: Test pdftoppm
-      run: D:\a\poppler-windows\poppler-windows\poppler-${{ env.POPPLER_VERSION }}\Library\bin\pdftoppm.exe -v
-    - name: Test pdftops
-      run: D:\a\poppler-windows\poppler-windows\poppler-${{ env.POPPLER_VERSION }}\Library\bin\pdftops.exe -v
-    - name: Test pdftotext
-      run: D:\a\poppler-windows\poppler-windows\poppler-${{ env.POPPLER_VERSION }}\Library\bin\pdftotext.exe -v
-    - name: Test pdfunite
-      run: D:\a\poppler-windows\poppler-windows\poppler-${{ env.POPPLER_VERSION }}\Library\bin\pdfunite.exe -v

--- a/package.sh
+++ b/package.sh
@@ -9,33 +9,11 @@ mkdir "poppler-$POPPLER_VERSION"
 cd "poppler-$POPPLER_VERSION" || exit
 
 cp -a "$PKGS_PATH_DIR"/poppler-$POPPLER_VERSION*/Library/ .
-cp "$PKGS_PATH_DIR"/libfreetype6*/Library/bin/freetype.dll ./Library/bin/
-cp "$PKGS_PATH_DIR"/libzlib*/Library/bin/zlib.dll ./Library/bin/
-cp -a "$PKGS_PATH_DIR"/zstd*/Library/bin/. ./Library/bin/
-cp "$PKGS_PATH_DIR"/libtiff*/Library/bin/tiff.dll ./Library/bin/
-cp "$PKGS_PATH_DIR"/libtiff*/Library/bin/libtiff.dll ./Library/bin/
-cp "$PKGS_PATH_DIR"/libssh2*/Library/bin/libssh2.dll ./Library/bin/
-cp "$PKGS_PATH_DIR"/libpng*/Library/bin/libpng16.dll ./Library/bin/
-cp "$PKGS_PATH_DIR"/libcurl*/Library/bin/libcurl.dll ./Library/bin/
-cp "$PKGS_PATH_DIR"/openssl*/Library/bin/libcrypto-3-x64.dll ./Library/bin/
-cp "$PKGS_PATH_DIR"/openjpeg*/Library/bin/openjp2.dll ./Library/bin/
-cp "$PKGS_PATH_DIR"/libjpeg-turbo*/Library/bin/jpeg8.dll ./Library/bin/
-cp "$PKGS_PATH_DIR"/liblzma*/Library/bin/liblzma.dll ./Library/bin/
-cp "$PKGS_PATH_DIR"/cairo*/Library/bin/cairo.dll ./Library/bin/
-# cp "$PKGS_PATH_DIR"/libdeflate*/Library/bin/libdeflate.dll ./Library/bin/
-cp "$PKGS_PATH_DIR"/libdeflate*/Library/bin/deflate.dll ./Library/bin/
-cp "$PKGS_PATH_DIR"/lerc*/Library/bin/Lerc.dll ./Library/bin/
-# cp "$PKGS_PATH_DIR"/jbig*/Library/bin/jbig.dll ./Library/bin/
-cp "$PKGS_PATH_DIR"/lcms2*/Library/bin/lcms2.dll ./Library/bin/
-cp "$PKGS_PATH_DIR"/fontconfig*/Library/bin/fontconfig-1.dll ./Library/bin/
-# cp "$PKGS_PATH_DIR"/expat*/Library/bin/libexpat.dll ./Library/bin/
-cp "$PKGS_PATH_DIR"/expat*/Library/bin/expat.dll ./Library/bin/
-cp "$PKGS_PATH_DIR"/expat*/Library/bin/expat.dll ./Library/bin/libexpat.dll
-cp -a "$PKGS_PATH_DIR"/libiconv*/Library/bin/. ./Library/bin/
-cp "$PKGS_PATH_DIR"/pixman*/Library/bin/*.dll ./Library/bin/
-cp "$PKGS_PATH_DIR"/vc14_runtime*/Library/bin/*.dll ./Library/bin/
-cp "$PKGS_PATH_DIR"/ucrt*/Library/bin/*.dll ./Library/bin/
-cp "$PKGS_PATH_DIR"/vcomp14*/Library/bin/*.dll ./Library/bin/
+
+# Bundle DLLs from the resolved environment instead of maintaining a brittle
+# list of transitive packages. GitHub's Windows bash needs a POSIX path.
+CONDA_PREFIX_DIR="$(cygpath --unix "$CONDA_PREFIX")"
+cp "$CONDA_PREFIX_DIR"/Library/bin/*.dll ./Library/bin/
 
 rm -rf "$PKGS_PATH_DIR"
 

--- a/package.sh
+++ b/package.sh
@@ -34,6 +34,8 @@ cp "$PKGS_PATH_DIR"/expat*/Library/bin/expat.dll ./Library/bin/libexpat.dll
 cp -a "$PKGS_PATH_DIR"/libiconv*/Library/bin/. ./Library/bin/
 cp "$PKGS_PATH_DIR"/pixman*/Library/bin/*.dll ./Library/bin/
 cp "$PKGS_PATH_DIR"/vc14_runtime*/Library/bin/*.dll ./Library/bin/
+cp "$PKGS_PATH_DIR"/ucrt*/Library/bin/*.dll ./Library/bin/
+cp "$PKGS_PATH_DIR"/vcomp14*/Library/bin/*.dll ./Library/bin/
 
 rm -rf "$PKGS_PATH_DIR"
 

--- a/package.sh
+++ b/package.sh
@@ -33,6 +33,7 @@ cp "$PKGS_PATH_DIR"/expat*/Library/bin/expat.dll ./Library/bin/
 cp "$PKGS_PATH_DIR"/expat*/Library/bin/expat.dll ./Library/bin/libexpat.dll
 cp -a "$PKGS_PATH_DIR"/libiconv*/Library/bin/. ./Library/bin/
 cp "$PKGS_PATH_DIR"/pixman*/Library/bin/*.dll ./Library/bin/
+cp "$PKGS_PATH_DIR"/vc14_runtime*/Library/bin/*.dll ./Library/bin/
 
 rm -rf "$PKGS_PATH_DIR"
 

--- a/package.sh
+++ b/package.sh
@@ -1,4 +1,4 @@
-POPPLER_VERSION=26.02.0
+POPPLER_VERSION=26.07.0
 POPPLER_DATA_URL="https://poppler.freedesktop.org/poppler-data-0.4.12.tar.gz"
 BUILD="0"
 

--- a/test-package.ps1
+++ b/test-package.ps1
@@ -17,7 +17,7 @@ if (-not (Test-Path -LiteralPath $SamplePdf -PathType Leaf)) {
     throw "Sample PDF not found: $SamplePdf"
 }
 
-# Only packaged DLLs and Windows system DLLs may satisfy runtime imports.
+# Remove Conda from DLL lookup so the package has to supply its own dependencies.
 $env:PATH = "$binDirectory;$env:SystemRoot\System32;$env:SystemRoot"
 
 function Invoke-Poppler {
@@ -35,23 +35,57 @@ function Invoke-Poppler {
     }
 }
 
-$attachedPdf = Join-Path ([System.IO.Path]::GetTempPath()) "poppler-attach-$([guid]::NewGuid()).pdf"
+$versionOnlyExecutables = @(
+    'pdffonts.exe',
+    'pdfimages.exe',
+    'pdfinfo.exe',
+    'pdfseparate.exe',
+    'pdfsig.exe',
+    'pdftocairo.exe',
+    'pdftohtml.exe',
+    'pdftoppm.exe',
+    'pdftops.exe',
+    'pdftotext.exe',
+    'pdfunite.exe'
+)
+
+$requiredExecutables = @(
+    'pdfattach.exe',
+    'pdfdetach.exe'
+) + ($versionOnlyExecutables | Where-Object { $_ -ne 'pdfsig.exe' })
+
+$packagedExecutables = @(
+    Get-ChildItem -LiteralPath $binDirectory -Filter 'pdf*.exe' -File |
+        Sort-Object Name |
+        Select-Object -ExpandProperty Name
+)
+$knownExecutables = @('pdfattach.exe', 'pdfdetach.exe') + $versionOnlyExecutables
+$untestedExecutables = @($packagedExecutables | Where-Object { $_ -notin $knownExecutables })
+$missingExecutables = @($requiredExecutables | Where-Object { $_ -notin $packagedExecutables })
+
+if ($untestedExecutables.Count -gt 0) {
+    throw "Packaged executables have no test: $($untestedExecutables -join ', ')"
+}
+
+if ($missingExecutables.Count -gt 0) {
+    throw "Required executables are missing: $($missingExecutables -join ', ')"
+}
+
+$workingDirectory = Join-Path ([System.IO.Path]::GetTempPath()) "poppler-test-$([guid]::NewGuid())"
+$attachedPdf = Join-Path $workingDirectory 'attached.pdf'
+New-Item -ItemType Directory -Path $workingDirectory | Out-Null
+Push-Location $workingDirectory
 
 try {
     Invoke-Poppler -Executable 'pdfattach.exe' -Arguments @($SamplePdf, $SamplePdf, $attachedPdf)
+    if (-not (Test-Path -LiteralPath $attachedPdf -PathType Leaf) -or
+        (Get-Item -LiteralPath $attachedPdf).Length -eq 0) {
+        throw 'pdfattach.exe did not produce a non-empty PDF'
+    }
+
     Invoke-Poppler -Executable 'pdfdetach.exe' -Arguments @('-list', $SamplePdf)
 
-    foreach ($executable in @(
-        'pdffonts.exe',
-        'pdfimages.exe',
-        'pdfinfo.exe',
-        'pdftocairo.exe',
-        'pdftohtml.exe',
-        'pdftoppm.exe',
-        'pdftops.exe',
-        'pdftotext.exe',
-        'pdfunite.exe'
-    )) {
+    foreach ($executable in $versionOnlyExecutables | Where-Object { $_ -in $packagedExecutables }) {
         Invoke-Poppler -Executable $executable -Arguments @('-v')
     }
 
@@ -63,5 +97,7 @@ try {
     }
 }
 finally {
+    Pop-Location
     Remove-Item -LiteralPath $attachedPdf -Force -ErrorAction SilentlyContinue
+    Remove-Item -LiteralPath $workingDirectory -Force -ErrorAction SilentlyContinue
 }

--- a/test-package.ps1
+++ b/test-package.ps1
@@ -1,0 +1,67 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [string] $PackageRoot,
+
+    [string] $SamplePdf = (Join-Path $PSScriptRoot 'sample.pdf')
+)
+
+$ErrorActionPreference = 'Stop'
+
+$binDirectory = Join-Path $PackageRoot 'Library\bin'
+if (-not (Test-Path -LiteralPath $binDirectory -PathType Container)) {
+    throw "Poppler bin directory not found: $binDirectory"
+}
+
+if (-not (Test-Path -LiteralPath $SamplePdf -PathType Leaf)) {
+    throw "Sample PDF not found: $SamplePdf"
+}
+
+# Only packaged DLLs and Windows system DLLs may satisfy runtime imports.
+$env:PATH = "$binDirectory;$env:SystemRoot\System32;$env:SystemRoot"
+
+function Invoke-Poppler {
+    param(
+        [Parameter(Mandatory)]
+        [string] $Executable,
+
+        [string[]] $Arguments = @()
+    )
+
+    $executablePath = Join-Path $binDirectory $Executable
+    & $executablePath @Arguments
+    if ($LASTEXITCODE -ne 0) {
+        throw "$Executable failed with exit code $LASTEXITCODE"
+    }
+}
+
+$attachedPdf = Join-Path ([System.IO.Path]::GetTempPath()) "poppler-attach-$([guid]::NewGuid()).pdf"
+
+try {
+    Invoke-Poppler -Executable 'pdfattach.exe' -Arguments @($SamplePdf, $SamplePdf, $attachedPdf)
+    Invoke-Poppler -Executable 'pdfdetach.exe' -Arguments @('-list', $SamplePdf)
+
+    foreach ($executable in @(
+        'pdffonts.exe',
+        'pdfimages.exe',
+        'pdfinfo.exe',
+        'pdftocairo.exe',
+        'pdftohtml.exe',
+        'pdftoppm.exe',
+        'pdftops.exe',
+        'pdftotext.exe',
+        'pdfunite.exe'
+    )) {
+        Invoke-Poppler -Executable $executable -Arguments @('-v')
+    }
+
+    foreach ($library in @('poppler-cpp.dll', 'poppler-glib.dll')) {
+        $handle = [System.Runtime.InteropServices.NativeLibrary]::Load(
+            (Join-Path $binDirectory $library)
+        )
+        [System.Runtime.InteropServices.NativeLibrary]::Free($handle)
+    }
+}
+finally {
+    Remove-Item -LiteralPath $attachedPdf -Force -ErrorAction SilentlyContinue
+}


### PR DESCRIPTION
Package for Poppler v26.07.0. This supersedes the incomplete runtime-DLL fix in #96.

## Root cause

The package assembled by #96 still exits with `0xC0000135` because the hand-maintained dependency copy list misses transitive DLLs, including `intl-8.dll`, `psl-5.dll`, `icuuc78.dll`, and `icudt78.dll`. Adding only the MSVC runtime does not close the dependency graph.

## Fix

- Pin the Conda install to the version declared in `package.sh`.
- Copy DLLs from the resolved Conda environment instead of maintaining a package-by-package list.
- Test the assembled directory before creating or publishing the archive.
- Remove Conda from `PATH` during tests so missing packaged DLLs cannot be masked by the build environment.
- Exercise every packaged `pdf*.exe`, perform a real `pdfattach` operation, and load the C++ and GLib bindings.
- Fail when expected CLIs disappear or a new CLI has no test coverage.

## Verification

- The original #96 artifact reproduces the failure: `pdfattach.exe` exits with `-1073741515` (`0xC0000135`).
- A rebuilt 26.07.0 package and its extracted ZIP pass all CLI and binding smoke tests.
- Recursive normal and delay-import scan: 134 PE files, 0 unresolved non-system imports.
- PowerShell parsing, `bash -n`, actionlint, and `git diff --check` pass.

## Poppler 26.09.0

26.09.0 is already released upstream, but conda-forge/poppler-feedstock#188 is still pending and no 26.09.0 win-64 package is published yet. The version stays at 26.07.0 so CI remains reproducible; once that package is available, only `POPPLER_VERSION` needs to be bumped.

# Checklist

- [x] I have confirmed that [poppler-feedstock](https://github.com/conda-forge/poppler-feedstock) has been updated for 26.07.0.
- [x] I have bumped `package.sh` `POPPLER_VERSION` to the current available Windows build.